### PR TITLE
Re-connect if a 401 error is received from the inverter

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -7,7 +7,6 @@ Source: http://www.github.com/kellerza/pysma
 import asyncio
 import json
 import logging
-import random
 
 import async_timeout
 


### PR DESCRIPTION
If a 401 error is received from the inverter (this seems to happen after about 24 hours) then close the session and try to re-authenticate.