### PR TITLE
Update __init__.py to support python 3.7

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -255,7 +255,7 @@ class SMA:
 
         if self.sma_uid is None:
             # Get the unique ID
-            self.sma_uid = next(body['result'].keys())
+            self.sma_uid = next(iter(body['result'].keys()))
 
         result_body = body['result'].pop(self.sma_uid, None)
 


### PR DESCRIPTION
In Python 3.x, dict.keys() does not return a list, it returns an iterable.