### PR TITLE
Add warning about password length

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -191,6 +191,8 @@ class SMA:
         """Init SMA connection."""
         if group not in USERS:
             raise KeyError("Invalid user type: {}".format(group))
+        if len(password) > 12:
+            _LOGGER.warn('Password should not exceed 12 characters')
         self._new_session_data = {"right": USERS[group], "pass": password}
         self._url = url.rstrip("/")
         if not url.startswith("http"):


### PR DESCRIPTION
This seems to have been confusing some people:
https://github.com/home-assistant/core/issues/26433

Especially now that some browsers no longer truncate on paste (or when you use a password manager):
https://www.fxsitecompat.dev/en-CA/docs/2020/text-exceeding-maxlength-will-no-longer-be-truncated-when-pasted-into-input-or-textarea/

Webconnect will just silently truncate upon save, so a warning might help people find what's wrong.