### PR TITLE
example.py: set verify_ssl=False, since SMA Inverters use invalid certs

### DIFF
--- a/example.py
+++ b/example.py
@@ -29,7 +29,8 @@ def print_table(sensors):
 
 async def main_loop(loop, password, user, ip):  # pylint: disable=invalid-name
     """Main loop."""
-    async with aiohttp.ClientSession(loop=loop) as session:
+    async with aiohttp.ClientSession(loop=loop,
+                                     connector=aiohttp.TCPConnector(verify_ssl=False)) as session:
         VAR["sma"] = pysma.SMA(session, ip, password=password, group=user)
         await VAR["sma"].new_session()
         if VAR["sma"].sma_sid is None:


### PR DESCRIPTION
SMA Inverters use self-signed certificates which are untrusted by default on Python.

Without this change, attempting to use example.py with HTTPS fails with:

```
$ python example.py https://sma.local user 1234
DEBUG:asyncio:Using selector: EpollSelector
ERROR:pysma:Could not start session, Could not connect to SMA at https://sma.local (timeout), got {}
INFO:__main__:No session ID
```

With this change, connecting works as expected.

In an ideal world, using a trusted TLS certificate would be the best fix. However, I'm unaware of a way to upload a trusted TLS cert to an SMA inverter. As such, setting verify_ssl=False seems to be the only practical way to use HTTPS with this hardware.