### PR TITLE
Increace async_timeout

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -225,7 +225,7 @@ class SMA:
         }
         for _ in range(3):
             try:
-                with async_timeout.timeout(3):
+                with async_timeout.timeout(10):
                     res = yield from self._aio_session.post(self._url + url, **params)
                     return (yield from res.json()) or {}
             except (asyncio.TimeoutError, client_exceptions.ClientError):


### PR DESCRIPTION
Since the new firmware for SUNNY BOY 1.5 / 2.0 / 2.5 (version 3), the webinterface of solar invertors is increasingly slow and seems to "sleep" after some time. The current 3 second timeout is to low for the Webinterface to start up, causing unnecassary timeouts.

Tested on my own installation and this fixes all timeout issues.