### PR TITLE
Implement device info and l10n retrieval

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,17 @@
 """Tests for pysma."""
+from aioresponses import aioresponses
+import pytest
+
+MOCK_DEVICE = {
+    "manufacturer": "SMA",
+    "name": "SMA Device Name",
+    "type": "Sunny Boy 3.6",
+    "serial": "123456789",
+}
+MOCK_L10N = {"461": "SMA", "9402": "Sunny Boy 3.6"}
+
+
+@pytest.fixture
+def mock_aioresponse():
+    with aioresponses() as m:
+        yield m

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,15 @@
 """Test pysma sensors."""
+from homeassistant.loader import async_get_dhcp
 import logging
+import aiohttp
 from json import loads
 from unittest.mock import patch
 
 import pytest
 
 import pysma
+
+from . import MOCK_L10N, MOCK_DEVICE, mock_aioresponse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,6 +92,7 @@ class Test_sensor_class:
     def test_default_no_duplicates(self, mock_warn):
         """Ensure warning on duplicates."""
         sen = pysma.Sensors()
+        assert len(sen) == 30
         assert mock_warn.call_count == 0
         # Add duplicate frequency
         news = pysma.Sensor("key1", "frequency", "")
@@ -100,6 +105,18 @@ class Test_sensor_class:
         # Add duplicate freq key only
         sen.add(pysma.Sensor("6100_00465700", "f001", ""))
         assert mock_warn.call_count == 3
+        # Test different key_idx only
+        sen.add(pysma.Sensor("key1_0", "frequency_0", ""))
+        assert mock_warn.call_count == 3
+        sen.add(pysma.Sensor("key1_1", "frequency_1", ""))
+        assert mock_warn.call_count == 3
+
+    @patch("pysma._LOGGER.warning")
+    def test_type_error(self, mock_warn):
+        """Ensure TypeError on not isinstance."""
+        sen = pysma.Sensors()
+        with pytest.raises(TypeError):
+            sen.add("This is not a Sensor")
 
     @patch("pysma._LOGGER.warning")
     def test_default_jmes(self, mock_warn):
@@ -110,9 +127,117 @@ class Test_sensor_class:
         assert mock_warn.called
 
 
-class Test_sms_connection:
-    async def test_init(self):
-        """Initialize & close the SMA transport class."""
-        aiosession = None
-        sma = pysma.SMA(aiosession, "192.168.0.100", "pass")
+class Test_SMA_class:
+    @pytest.fixture(autouse=True)
+    def _setup(self, mock_aioresponse):
+        self.host = "1.1.1.1"
+        self.base_url = f"http://{self.host}"
+        mock_aioresponse.get(
+            f"{self.base_url}/data/l10n/en-US.json",
+            payload=MOCK_L10N,
+        )
+        mock_aioresponse.post(f"{self.base_url}/dyn/logout.json?sid=ABCD", payload={})
+
+    @patch("pysma._LOGGER.warning")
+    async def test_session(self, mock_warn, mock_aioresponse):
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/login.json", payload={"result": {"sid": "ABCD"}}
+        )
+        session = aiohttp.ClientSession()
+        sma = pysma.SMA(session, self.host, "extralongpassword")
+        assert await sma.new_session()
+
+        assert mock_warn.call_count == 1
         await sma.close_session()
+        await sma.close_session()
+
+        assert mock_warn.call_count == 1
+
+    async def test_new_session_invalid_group(self, mock_aioresponse):
+        session = aiohttp.ClientSession()
+        with pytest.raises(KeyError):
+            pysma.SMA(session, self.host, "pass", "invalid-group")
+
+    async def test_new_session_fail(self, mock_aioresponse):
+        mock_aioresponse.post(f"{self.base_url}/dyn/login.json", payload={"result": {}})
+
+        session = aiohttp.ClientSession()
+        sma = pysma.SMA(session, self.host, "pass")
+        assert not await sma.new_session()
+
+    async def test_device_info(self, mock_aioresponse):
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/login.json", payload={"result": {"sid": "ABCD"}}
+        )
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/getValues.json?sid=ABCD",
+            payload={
+                "result": {
+                    "0199-xxxxx385": {
+                        "6800_08822B00": {
+                            "1": [{"validVals": [461], "val": [{"tag": 461}]}]
+                        },
+                        "6800_00A21E00": {
+                            "1": [
+                                {"low": 0, "high": None, "val": MOCK_DEVICE["serial"]}
+                            ]
+                        },
+                        "6800_08822000": {
+                            "1": [
+                                {
+                                    "validVals": [9401, 9402, 9403, 9404, 9405],
+                                    "val": [{"tag": 9402}],
+                                }
+                            ]
+                        },
+                        "6800_10821E00": {"1": [{"val": MOCK_DEVICE["name"]}]},
+                    }
+                }
+            },
+        )
+        session = aiohttp.ClientSession()
+        sma = pysma.SMA(session, self.host, "pass")
+        result = await sma.device_info()
+        assert result
+        assert result == MOCK_DEVICE
+
+    async def test_device_info_fallback(self, mock_aioresponse):
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/login.json", payload={"result": {"sid": "ABCD"}}
+        )
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/getValues.json?sid=ABCD",
+            payload={
+                "result": {
+                    "0199-xxxxx385": {
+                        "6800_08822B00": {
+                            "1": [{"validVals": [461], "val": [{"tag": 461}]}]
+                        },
+                        "6800_10821E00": {"1": [{"val": MOCK_DEVICE["name"]}]},
+                    }
+                }
+            },
+        )
+        session = aiohttp.ClientSession()
+        sma = pysma.SMA(session, self.host, "pass")
+        assert await sma.new_session()
+        result = await sma.device_info()
+        assert result
+        assert result["manufacturer"] == "SMA"
+        assert result["name"] == MOCK_DEVICE["name"]
+        assert result["type"] == ""
+        assert result["serial"] == "9999999999"
+
+    async def test_device_info_fail(self, mock_aioresponse):
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/login.json", payload={"result": {"sid": "ABCD"}}
+        )
+        mock_aioresponse.post(
+            f"{self.base_url}/dyn/getValues.json?sid=ABCD",
+            payload={},
+        )
+        session = aiohttp.ClientSession()
+        sma = pysma.SMA(session, self.host, "pass")
+        assert await sma.new_session()
+        result = await sma.device_info()
+        assert not result


### PR DESCRIPTION
Move device info logic to pysma lib for https://github.com/home-assistant/core/pull/48003

Not sure if it is the most elegant solution, but it works.
I have also extended the tests and coverage is now 89%