### PR TITLE
Remove duplicate sensor keys

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -36,7 +36,7 @@ class Sensor:
 
     def __attrs_post_init__(self):
         """Init path."""
-        idx = 0
+        idx = "0"
         key = str(self.key)
         if key[-2] == "_" and key[-1].isdigit():
             idx = key[-1]
@@ -120,10 +120,8 @@ class Sensors:
                     Sensor("6100_0046C200", "pv_power", "W"),
                     Sensor("6380_40251E00_0", "pv_power_a", "W"),
                     Sensor("6380_40251E00_1", "pv_power_b", "W"),
-                    Sensor("6380_40451F00", "pv_voltage", "V", 100),
                     Sensor("6380_40451F00_0", "pv_voltage_a", "V", 100),
                     Sensor("6380_40451F00_1", "pv_voltage_b", "V", 100),
-                    Sensor("6380_40452100", "pv_current", "A", 1000),
                     Sensor("6380_40452100_0", "pv_current_a", "A", 1000),
                     Sensor("6380_40452100_1", "pv_current_b", "A", 1000),
                     Sensor("6400_0046C300", "pv_gen_meter", "kWh", 1000),

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -184,7 +184,7 @@ class Sensors:
             self.__s.remove(old)
             _LOGGER.warning("Replacing sensor %s with %s", old, sensor)
 
-        if sensor.key in self and self[sensor.key].key_idx is sensor.key_idx:
+        if sensor.key in self and self[sensor.key].key_idx == sensor.key_idx:
             _LOGGER.warning(
                 "Duplicate SMA sensor key %s (idx: %s)", sensor.key, sensor.key_idx
             )

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -32,7 +32,7 @@ class Sensor:
     factor = attr.ib(default=None)
     path = attr.ib(default=None)
     value = attr.ib(default=None, init=False)
-    key_idx = attr.ib(default=0, repr=False, init=False)
+    key_idx = attr.ib(default="0", repr=False, init=False)
 
     def __attrs_post_init__(self):
         """Init path."""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from setuptools import setup
 
-VERSION = "0.4"
+VERSION = "0.4.1"
 URL = "https://github.com/kellerza/pysma"
 
 setup(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -92,7 +92,7 @@ class Test_sensor_class:
     def test_default_no_duplicates(self, mock_warn):
         """Ensure warning on duplicates."""
         sen = pysma.Sensors()
-        assert len(sen) == 30
+        assert len(sen) == 28
         assert mock_warn.call_count == 0
         # Add duplicate frequency
         news = pysma.Sensor("key1", "frequency", "")


### PR DESCRIPTION
idx is stored as a sting, so default should be string too.
Two sensors removed to make test pass again.