### PR TITLE
Sensor enabled and l10n_translate attributes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from setuptools import setup
 
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 URL = "https://github.com/kellerza/pysma"
 
 setup(


### PR DESCRIPTION
Two changes, will bump version to `0.4.3`

### Sensor enabled attribute
Allows to easily disable specific sensors. Makes it easy to handle disabling entities. As requested in https://github.com/home-assistant/core/pull/48003
As soon as an entity is disabled in HA, we can disable the corresponding sensor in pysma to stop the polling of data of that specific sensor.

### Sensor l10n_translate attribute
When the l10n_translate is set to `True`, the sensor will automatically translate the retrieved ID using the l10n file.
If no match is found it defaults to the original value.
Usefull for the status sensor. This will now show Ok instead of a number.
Was already used in `device_info()`, but now made more generic