### PR TITLE
Add exceptions and restructure _fetch_json

### DIFF
--- a/example.py
+++ b/example.py
@@ -34,9 +34,14 @@ async def main_loop(loop, password, user, url):
         loop=loop, connector=aiohttp.TCPConnector(ssl=False)
     ) as session:
         VAR["sma"] = pysma.SMA(session, url, password=password, group=user)
-        await VAR["sma"].new_session()
-        if VAR["sma"].sma_sid is None:
-            _LOGGER.info("No session ID")
+
+        try:
+            await VAR["sma"].new_session()
+        except pysma.exceptions.SmaAuthenticationException:
+            _LOGGER.warning("Authentication failed!")
+            return
+        except pysma.exceptions.SmaConnectionException:
+            _LOGGER.warning("Unable to connect to device at %s", url)
             return
 
         _LOGGER.info("NEW SID: %s", VAR["sma"].sma_sid)

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -11,13 +11,6 @@ import logging
 import jmespath  # type: ignore
 from aiohttp import ClientTimeout, client_exceptions, hdrs
 
-from pysma.exceptions import (
-    SmaAuthenticationException,
-    SmaConnectionException,
-    SmaReadException,
-)
-from pysma.helpers import version_int_to_string
-
 from . import definitions
 from .const import (
     DEFAULT_TIMEOUT,
@@ -34,6 +27,12 @@ from .const import (
     URL_VALUES,
     USERS,
 )
+from .exceptions import (
+    SmaAuthenticationException,
+    SmaConnectionException,
+    SmaReadException,
+)
+from .helpers import version_int_to_string
 from .sensor import Sensors
 
 _LOGGER = logging.getLogger(__name__)

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -4,19 +4,23 @@ See: http://www.sma.de/en/products/monitoring-control/webconnect.html
 
 Source: http://www.github.com/kellerza/pysma
 """
-import asyncio
 import copy
 import json
 import logging
 
-import async_timeout
 import jmespath  # type: ignore
-from aiohttp import client_exceptions
+from aiohttp import ClientTimeout, client_exceptions, hdrs
 
+from pysma.exceptions import (
+    SmaAuthenticationException,
+    SmaConnectionException,
+    SmaReadException,
+)
 from pysma.helpers import version_int_to_string
 
 from . import definitions
 from .const import (
+    DEFAULT_TIMEOUT,
     DEVCLASS_INVERTER,
     DEVICE_INFO,
     ENERGY_METER_VIA_INVERTER,
@@ -60,36 +64,57 @@ class SMA:
         self.devclass = None
         self.device_info_sensors = Sensors(definitions.sensor_map[DEVICE_INFO])
 
-    async def _fetch_json(self, url, payload):
-        """Fetch json data for requests."""
-        params = {
-            "data": json.dumps(payload),
-            "headers": {"content-type": "application/json"},
-            "params": {"sid": self.sma_sid} if self.sma_sid else None,
-        }
-        for _ in range(3):
-            try:
-                with async_timeout.timeout(10):
-                    res = await self._aio_session.post(self._url + url, **params)
-                    return (await res.json()) or {}
-            except (asyncio.TimeoutError, client_exceptions.ClientError):
-                continue
-        return {"err": "Could not connect to SMA at {} (timeout)".format(self._url)}
+    async def _request_json(self, method, url, **kwargs):
+        """Request json data for requests."""
+        if self.sma_sid:
+            kwargs.setdefault("params", {})
+            kwargs["params"]["sid"] = self.sma_sid
+
+        try:
+            res = await self._aio_session.request(
+                method,
+                self._url + url,
+                timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
+                **kwargs,
+            )
+        except client_exceptions.ClientError as exc:
+            raise SmaConnectionException(
+                f"Could not connect to SMA at {self._url}"
+            ) from exc
+
+        try:
+            res_json = await res.json()
+        except client_exceptions.ContentTypeError:
+            _LOGGER.warning("Request to %s did not return a valid json.", url)
+            return {}
+
+        return res_json
+
+    async def _get_json(self, url):
+        """Get json data for requests."""
+        return await self._request_json(hdrs.METH_GET, url)
+
+    async def _post_json(self, url, payload=None):
+        """Post json data for requests."""
+        params = {}
+        if payload is not None:
+            params["data"] = json.dumps(payload)
+            params["headers"] = {"content-type": "application/json"}
+
+        return await self._request_json(hdrs.METH_POST, url, **params)
 
     async def _read_l10n(self, lang="en-US"):
         """Read device language file."""
-        res = await self._aio_session.get(f"{self._url}/data/l10n/{lang}.json")
-        return (await res.json()) or {}
+        return await self._get_json(f"/data/l10n/{lang}.json")
 
     async def _read_body(self, url, payload):
         if self.sma_sid is None and self._new_session_data is not None:
             await self.new_session()
-            if self.sma_sid is None:
-                return None
-        body = await self._fetch_json(url, payload=payload)
+        body = await self._post_json(url, payload)
 
         # On the first error we close the session which will re-login
         err = body.get("err")
+
         if err is not None:
             _LOGGER.warning(
                 "%s: error detected, closing session to force another login attempt, got: %s",
@@ -97,11 +122,11 @@ class SMA:
                 body,
             )
             await self.close_session()
-            return None
+            raise SmaReadException("Error detected while reading")
 
-        if not isinstance(body, dict) or "result" not in body:
+        if "result" not in body:
             _LOGGER.warning("No 'result' in reply from SMA, got: %s", body)
-            return None
+            raise SmaReadException("No 'result' in reply from SMA")
 
         if self.sma_uid is None:
             # Get the unique ID
@@ -120,7 +145,7 @@ class SMA:
     async def new_session(self):
         """Establish a new session."""
         self.l10n = await self._read_l10n()
-        body = await self._fetch_json(URL_LOGIN, self._new_session_data)
+        body = await self._post_json(URL_LOGIN, self._new_session_data)
         self.sma_sid = jmespath.search("result.sid", body)
         if self.sma_sid:
             return True
@@ -135,14 +160,15 @@ class SMA:
                 _LOGGER.error(msg, err)
         else:
             _LOGGER.error(msg, "Session ID expected [result.sid]")
-        return False
+
+        raise SmaAuthenticationException()
 
     async def close_session(self):
         """Close the session login."""
         if self.sma_sid is None:
             return
         try:
-            await self._fetch_json(URL_LOGOUT, {})
+            await self._post_json(URL_LOGOUT)
         finally:
             self.sma_sid = None
 
@@ -202,9 +228,7 @@ class SMA:
 
     async def device_info(self):
         """Read device info and return the results."""
-        values = await self.read(self.device_info_sensors)
-        if not values:
-            return False
+        await self.read(self.device_info_sensors)
 
         device_info = {
             "serial": self.device_info_sensors["serial_number"].value

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -70,6 +70,8 @@ class SMA:
             kwargs.setdefault("params", {})
             kwargs["params"]["sid"] = self.sma_sid
 
+        _LOGGER.debug("Sending %s request to %s: %s", method, url, kwargs)
+
         try:
             res = await self._aio_session.request(
                 method,
@@ -84,11 +86,11 @@ class SMA:
 
         try:
             res_json = await res.json()
-        except client_exceptions.ContentTypeError:
+        except (client_exceptions.ContentTypeError, json.decoder.JSONDecodeError):
             _LOGGER.warning("Request to %s did not return a valid json.", url)
             return {}
 
-        return res_json
+        return res_json or {}
 
     async def _get_json(self, url):
         """Get json data for requests."""

--- a/pysma/const.py
+++ b/pysma/const.py
@@ -8,6 +8,8 @@ URL_DASH_VALUES = "/dyn/getDashValues.json"
 
 USERS = {"user": "usr", "installer": "istl"}
 
+DEFAULT_TIMEOUT = 15
+
 JMESPATH_VAL = "val"
 JMESPATH_VAL_TAG = JMESPATH_VAL + "[0].tag"
 JMESPATH_VAL_IDX = '"{}"[{}].val'

--- a/pysma/exceptions.py
+++ b/pysma/exceptions.py
@@ -1,0 +1,17 @@
+"""Exceptions for the pysma library."""
+
+
+class SmaException(Exception):
+    """Base exception of the pysma library"""
+
+
+class SmaAuthenticationException(SmaException):
+    """An attempt to authenticate failed."""
+
+
+class SmaReadException(SmaException):
+    """Reading the data did not return an expected result."""
+
+
+class SmaConnectionException(SmaException):
+    """An error occurred in the connection with the device."""

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     author_email="kellerza@gmail.com",
     license="MIT",
     packages=["pysma"],
-    install_requires=["aiohttp>3,<4", "async_timeout>3,<4", "attrs>18", "jmespath<2"],
+    install_requires=["aiohttp>3.3,<4", "attrs>18", "jmespath<2"],
     zip_safe=True,
 )


### PR DESCRIPTION
Add exceptions. All methods should return a valid value. If not, an exception should be raise.
These exceptions can be handled in HA to more easily provide feedback when things go wrong during setup or polling of data.
- For example raise `ConfigEntryNotReady` if unable to connect during entry setup
- Makes it easier to create a reauth flow in the future
-----

Also `_fetch_json` has been renamed to `_post_json` and new method `_get_json` was added. These both call `_request_json`.
- timeouts are now handled by `ClientTimeout` instead of `async_timeout` (dependency removed)
- retries using `for _ in range(3)` have been removed. It just fails and the `DataCoordinator` in HA will handle the retries.