### PR TITLE
Refactored read_logger

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -206,26 +206,47 @@ class SMA:
 
         return True
 
-    async def read_logger(self, sensors=None, start=None, end=None):
-        """Read a logging key and return the results."""
-        if self._new_session_data is None:
-            payload = {"destDev": [], "key": []}
-            result_body = await self._read_body(URL_DASH_LOGGER, payload)
-        else:
-            payload = {
-                "destDev": [],
-                "key": int(sensors[0].key),
-                "tStart": start,
-                "tEnd": end,
-            }
-            result_body = await self._read_body(URL_LOGGER, payload)
-        if not result_body:
-            return False
+    async def read_dash_logger(self) -> dict:
+        """Read the dash loggers.
 
-        for sen in sensors:
-            sen.extract_logger(result_body)
+        Returns:
+            dict: Dictionary containing loggers returned by device.
+        """
+        return await self._read_body(URL_DASH_LOGGER, {"destDev": [], "key": []})
 
-        return True
+    async def read_logger(self, log_id: int, start: int, end: int) -> list:
+        """Read a logging key and return the results.
+
+        Args:
+            log_id (int): The ID of the log to read.
+                totWhOut5min: 28672
+                totWhOutDaily: 28704
+                GridMsTotWhOutDaily: 28752
+                GridMsTotWhInDaily: 28768
+                ObjLogBatCha: 28816
+                totWhIn5min: 28736
+                totWhInDaily: 28768
+                ObjLogBatChrg: 29344
+                ObjLogBatDsch: 29360
+            start (int): Start timestamp in seconds.
+            end (int): End timestamp in seconds.
+
+        Returns:
+            list: The log entries returned by the device
+        """
+        payload = {
+            "destDev": [],
+            "key": log_id,
+            "tStart": start,
+            "tEnd": end,
+        }
+        result_body = await self._read_body(URL_LOGGER, payload)
+        if not isinstance(result_body, list):
+            raise SmaReadException(
+                "List of log entries expected. Response from inverter: %s", result_body
+            )
+
+        return result_body
 
     async def device_info(self):
         """Read device info and return the results."""

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -242,9 +242,7 @@ class SMA:
         }
         result_body = await self._read_body(URL_LOGGER, payload)
         if not isinstance(result_body, list):
-            raise SmaReadException(
-                "List of log entries expected. Response from inverter: %s", result_body
-            )
+            raise SmaReadException("List of log entries expected.")
 
         return result_body
 

--- a/pysma/sensor.py
+++ b/pysma/sensor.py
@@ -32,14 +32,6 @@ class Sensor:  # pylint: disable=too-many-instance-attributes
             self.key = f"{skey[0]}_{skey[1]}"
             self.key_idx = skey[2]
 
-    def extract_logger(self, result_body):
-        """Extract logs from json body.
-
-        Args:
-            result_body: json body retrieved from device
-        """
-        self.value = result_body
-
     def extract_value(self, result_body, l10n=None, devclass="1"):
         """Extract value from json body.
 

--- a/pysma/sensor.py
+++ b/pysma/sensor.py
@@ -11,9 +11,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @attr.s(slots=True)
-class Sensor:  # pylint: disable=too-many-instance-attributes
+class Sensor:
     """pysma sensor."""
 
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-few-public-methods
     key = attr.ib()
     name = attr.ib()
     unit = attr.ib(default="")

--- a/pysma/sensor.py
+++ b/pysma/sensor.py
@@ -17,17 +17,17 @@ class Sensor:
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-few-public-methods
-    key = attr.ib()
-    name = attr.ib()
-    unit = attr.ib(default="")
-    factor = attr.ib(default=None)
-    path = attr.ib(default=None)
-    enabled = attr.ib(default=True)
-    l10n_translate = attr.ib(default=False)
-    value = attr.ib(default=None, init=False)
-    key_idx = attr.ib(default="0", repr=False, init=False)
+    key: str = attr.ib()
+    name: str = attr.ib()
+    unit: str = attr.ib(default="")
+    factor: int = attr.ib(default=None)
+    path: Union[list, tuple] = attr.ib(default=None)
+    enabled: bool = attr.ib(default=True)
+    l10n_translate: bool = attr.ib(default=False)
+    value: Any = attr.ib(default=None, init=False)
+    key_idx: int = attr.ib(default=0, repr=False, init=False)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         """Init path."""
         key = str(self.key)
         skey = key.split("_")
@@ -35,7 +35,9 @@ class Sensor:
             self.key = f"{skey[0]}_{skey[1]}"
             self.key_idx = int(skey[2])
 
-    def extract_value(self, result_body, l10n=None, devclass="1"):
+    def extract_value(
+        self, result_body: dict, l10n: Optional[dict] = None, devclass: str = "1"
+    ) -> bool:
         """Extract value from json body.
 
         Args:


### PR DESCRIPTION
This splits the `read_logger` method in `read_logger` and `read_dash_logger`
The `sensors` parameter of  `read_logger` is replaced by `log_id`

`extract_logger` is not needed anymore in `Sensor` and removed.

I will add some test later this week to cover these methods.