### PR TITLE
Remove output of sma_sid, because it doesn't always exist

### DIFF
--- a/example.py
+++ b/example.py
@@ -44,8 +44,6 @@ async def main_loop(loop, password, user, url):
             _LOGGER.warning("Unable to connect to device at %s", url)
             return
 
-        _LOGGER.info("NEW SID: %s", VAR["sma"].sma_sid)
-
         # We should not get any exceptions, but if we do we will close the session.
         try:
             VAR["running"] = True

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -231,6 +231,7 @@ class SMA:
         body = await self._post_json(URL_LOGIN, self._new_session_data)
         self._sid = jmespath.search("result.sid", body)
         if self._sid:
+            _LOGGER.debug("New SID: %s", self._sid)
             return True
 
         err = body.pop("err", None)


### PR DESCRIPTION
I have a SunnyBoy 5.0, and this particular attribute doesn't exist. It is `_sid` instead for me. Since the traceback isn't all that great for newbies approaching the project, I think it might be better to just leave this part out.

Traceback, for reference:

```
Traceback (most recent call last):
  File "/home/msarahan/code/monitoring/sensors/example.py", line 104, in <module>
    main()
  File "/home/msarahan/code/monitoring/sensors/example.py", line 98, in main
    loop.run_until_complete(
  File "/home/msarahan/.local/share/r-miniconda/envs/sma/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/msarahan/code/monitoring/sensors/example.py", line 50, in main_loop
    _LOGGER.info("NEW SID: %s", VAR["sma"].sma_sid)
AttributeError: 'SMA' object has no attribute 'sma_sid'
```