### PR TITLE
Always send a payload

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -121,7 +121,9 @@ class SMA:
                     timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
                     **kwargs,
                 ) as res:
-                    return await res.json() or {}
+                    res_json = await res.json()
+                    _LOGGER.debug("Received reply %s", res_json)
+                    return res_json or {}
             except (client_exceptions.ContentTypeError, json.decoder.JSONDecodeError):
                 _LOGGER.warning("Request to %s did not return a valid json.", url)
                 break
@@ -159,15 +161,18 @@ class SMA:
 
         Args:
             url (str): URL to do POST request to
-            payload (dict, optional): payload to send to device. Defaults to None.
+            payload (dict, optional): payload to send to device. Defaults to empty dict.
 
         Returns:
             dict: json returned by device
         """
-        params: Dict[str, Any] = {}
-        if payload is not None:
-            params["data"] = json.dumps(payload)
-            params["headers"] = {"content-type": "application/json"}
+        if payload is None:
+            payload = {}
+
+        params: Dict[str, Any] = {
+            "data": json.dumps(payload),
+            "headers": {"content-type": "application/json"},
+        }
 
         return await self._request_json(hdrs.METH_POST, url, **params)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -532,3 +532,25 @@ class Test_SMA_class:
         sma = SMA(session, self.host, "pass")
         with pytest.raises(SmaReadException):
             await sma.get_sensors()
+
+    async def test_post_json(self):
+        session = aiohttp.ClientSession()
+        sma = SMA(session, self.host, "pass")
+
+        with patch("pysma.SMA._request_json") as mock_request_json:
+            await sma._post_json("dummy_url")
+            mock_request_json.assert_called_once_with(
+                "POST",
+                "dummy_url",
+                data="{}",
+                headers={"content-type": "application/json"},
+            )
+
+        with patch("pysma.SMA._request_json") as mock_request_json:
+            await sma._post_json("dummy_url", {"data": "dummy"})
+            mock_request_json.assert_called_once_with(
+                "POST",
+                "dummy_url",
+                data='{"data": "dummy"}',
+                headers={"content-type": "application/json"},
+            )


### PR DESCRIPTION
The logout function was not working properly. The device always expects a payload in the POST request.

fixes https://github.com/home-assistant/core/issues/52963