### PR TITLE
Set res to 0 only if unit is "W"

### DIFF
--- a/pysma/sensor.py
+++ b/pysma/sensor.py
@@ -88,8 +88,9 @@ class Sensor:
 
             # SMA will return None instead of 0 if if no power is generated
             # If we have extracted a path, we know the value was previously
-            # present and res can be set to 0
-            if res is None:
+            # present and res can be set to 0. We will only do this for "W"
+            # to prevent issues with energy totals in HA.
+            if res is None and self.unit == "W":
                 res = 0
         else:
             _LOGGER.debug(

--- a/pysma/sensor.py
+++ b/pysma/sensor.py
@@ -85,18 +85,16 @@ class Sensor:
         # Extract new value
         if isinstance(self.path, str):
             res = jmespath.search(self.path, res)
-
-            # SMA will return None instead of 0 if if no power is generated
-            # If we have extracted a path, we know the value was previously
-            # present and res can be set to 0. We will only do this for "W"
-            # to prevent issues with energy totals in HA.
-            if res is None and self.unit == "W":
-                res = 0
         else:
             _LOGGER.debug(
                 "Sensor %s: No successful value decoded yet: %s", self.name, res
             )
             res = None
+
+        # SMA will return None instead of 0 if if no power is generated
+        # For "W" sensors we will set it to 0 by default.
+        if res is None and self.unit == "W":
+            res = 0
 
         if isinstance(res, (int, float)) and self.factor:
             res /= self.factor

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -86,6 +86,7 @@ class Test_sensor_class:
         assert sens.extract_value({}) is False
         assert sens.value is None
 
+        # For "W" sensors we will set it to 0 by default.
         sens = Sensor("6100_40263F00", "s_null", "W")
         assert sens.extract_value({"6100_40263F00": {"val": None}}) is True
         assert sens.value == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -78,7 +78,7 @@ class Test_sensor_class:
 
     def test_null(self):
         """Test a null or None result."""
-        sens = Sensor("6100_40263F00", "s_null", "W")
+        sens = Sensor("6100_40263F00", "s_null", "kWh")
         assert sens.extract_value({"6100_40263F00": {"val": None}}) is False
         assert sens.value is None
         assert sens.extract_value({"6100_40263F00": {"1": [{"val": None}]}}) is False
@@ -86,14 +86,18 @@ class Test_sensor_class:
         assert sens.extract_value({}) is False
         assert sens.value is None
 
-        # After a valid value was seen. The next None value should be 0
-        assert sens.extract_value({"6100_40263F00": {"val": "dummy"}}) is True
-        assert sens.value == "dummy"
+        sens = Sensor("6100_40263F00", "s_null", "W")
         assert sens.extract_value({"6100_40263F00": {"val": None}}) is True
         assert sens.value == 0
+        assert sens.extract_value({"6100_40263F00": {"1": [{"val": None}]}}) is False
+        assert sens.value == 0
+        assert sens.extract_value({}) is True
+        assert sens.value is None
 
     def test_no_value_decoded(self):
         sens = Sensor("6100_40263F00", "s_null", "W")
+        assert sens.extract_value({"6100_40263F00": None}) is True
+        sens = Sensor("6100_40263F00", "s_null", "kWh")
         assert sens.extract_value({"6100_40263F00": None}) is False
 
 


### PR DESCRIPTION
Fixes https://github.com/kellerza/pysma/issues/93 and https://github.com/home-assistant/core/issues/61838

As setting everything back to 0 can cause issues with HA Statistics, I propose to set it only to 0 for sensors with unit "W".