### PR TITLE
Handle TimeoutError

### DIFF
--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -144,9 +144,9 @@ class SMA:
                     f"Could not connect to SMA at {self._url}: {exc}"
                 ) from exc
             except asyncio.TimeoutError:
-                raise SmaConnectionException(
+                raise SmaConnectionException(  # pylint: disable=raise-missing-from
                     f"Could not connect to SMA at {self._url}: TimeoutError"
-                )  # pylint: disable=raise-missing-from
+                )
 
         return {}
 

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -146,7 +146,7 @@ class SMA:
             except asyncio.TimeoutError:
                 raise SmaConnectionException(
                     f"Could not connect to SMA at {self._url}: TimeoutError"
-                )
+                )  # pylint: disable=raise-missing-from
 
         return {}
 

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -139,14 +139,13 @@ class SMA:
                 raise SmaConnectionException(
                     f"Server at {self._url} disconnected {max_retries+1} times."
                 ) from exc
-            except client_exceptions.ClientError as exc:
+            except (
+                client_exceptions.ClientError,
+                asyncio.exceptions.TimeoutError,
+            ) as exc:
                 raise SmaConnectionException(
                     f"Could not connect to SMA at {self._url}: {exc}"
                 ) from exc
-            except asyncio.TimeoutError:
-                raise SmaConnectionException(  # pylint: disable=raise-missing-from
-                    f"Could not connect to SMA at {self._url}: TimeoutError"
-                )
 
         return {}
 

--- a/pysma/__init__.py
+++ b/pysma/__init__.py
@@ -4,6 +4,7 @@ See: http://www.sma.de/en/products/monitoring-control/webconnect.html
 
 Source: http://www.github.com/kellerza/pysma
 """
+import asyncio
 import copy
 import json
 import logging
@@ -142,6 +143,10 @@ class SMA:
                 raise SmaConnectionException(
                     f"Could not connect to SMA at {self._url}: {exc}"
                 ) from exc
+            except asyncio.TimeoutError:
+                raise SmaConnectionException(
+                    f"Could not connect to SMA at {self._url}: TimeoutError"
+                )
 
         return {}
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 """Test pysma init."""
+import asyncio
 import logging
 import re
 from unittest.mock import patch
@@ -61,6 +62,18 @@ class Test_SMA_class:
         mock_aioresponse.get(
             f"{self.base_url}/dummy-url",
             exception=aiohttp.client_exceptions.ServerDisconnectedError("mocked error"),
+            repeat=True,
+        )
+        session = aiohttp.ClientSession()
+        sma = SMA(session, self.host, "pass")
+        with pytest.raises(SmaConnectionException):
+            await sma._get_json("/dummy-url")
+
+    async def test_timeout_error(self, mock_aioresponse):  # noqa: F811
+        """Test request_json with a SmaConnectionException from TimeoutError."""
+        mock_aioresponse.get(
+            f"{self.base_url}/dummy-url",
+            exception=asyncio.TimeoutError("mocked error"),
             repeat=True,
         )
         session = aiohttp.ClientSession()


### PR DESCRIPTION
Suggestion to fix https://github.com/home-assistant/core/issues/68999

Raising a SmaConnectionException instead of TimeoutError should allow HA to retry the setup later

1. This results in a ConfigEntryNotReady  [here](https://github.com/home-assistant/core/blob/dev/homeassistant/components/sma/__init__.py#L59)
2. And a retry [here](https://github.com/home-assistant/core/blob/dev/homeassistant/config_entries.py#L359)