### PR TITLE
Add definitions for the Secure Power Supply

### DIFF
--- a/pysma/definitions.py
+++ b/pysma/definitions.py
@@ -271,9 +271,13 @@ pv_gen_meter = Sensor("6400_0046C300", "pv_gen_meter", unit="kWh", factor=1000)
 
 # AC Side - Emergency power measurements (Secure Power Supply)
 #: Secure power supply voltage
-sps_voltage = Sensor("6100_0046C600", "sps_voltage", unit="V", factor=100, enabled=False)
+sps_voltage = Sensor(
+    "6100_0046C600", "sps_voltage", unit="V", factor=100, enabled=False
+)
 #: Secure power supply current
-sps_current = Sensor("6100_0046C700", "sps_current", unit="A", factor=1000, enabled=False)
+sps_current = Sensor(
+    "6100_0046C700", "sps_current", unit="A", factor=1000, enabled=False
+)
 #: Secure power supply power
 sps_power = Sensor("6100_0046C800", "sps_power", unit="W", enabled=False)
 

--- a/pysma/definitions.py
+++ b/pysma/definitions.py
@@ -273,9 +273,9 @@ pv_gen_meter = Sensor("6400_0046C300", "pv_gen_meter", unit="kWh", factor=1000)
 #: Secure power supply voltage
 sps_voltage = Sensor("6100_0046C600", "sps_voltage", unit="V", factor=100, enabled=False)
 #: Secure power supply current
-sps_current = Sensor("6100_0046C600", "sps_current", unit="A", factor=1000, enabled=False)
+sps_current = Sensor("6100_0046C700", "sps_current", unit="A", factor=1000, enabled=False)
 #: Secure power supply power
-sps_power = Sensor("6100_0046C600", "sps_power", unit="W", enabled=False)
+sps_power = Sensor("6100_0046C800", "sps_power", unit="W", enabled=False)
 
 # PV Inverter Optimizers
 #: Serial number of optimizer

--- a/pysma/definitions.py
+++ b/pysma/definitions.py
@@ -269,6 +269,14 @@ metering_total_consumption = Sensor(
 #: Total kWh generated to date
 pv_gen_meter = Sensor("6400_0046C300", "pv_gen_meter", unit="kWh", factor=1000)
 
+# AC Side - Emergency power measurements (Secure Power Supply)
+#: Secure power supply voltage
+sps_voltage = Sensor("6100_0046C600", "sps_voltage", unit="V", factor=100, enabled=False)
+#: Secure power supply current
+sps_current = Sensor("6100_0046C600", "sps_current", unit="A", factor=1000, enabled=False)
+#: Secure power supply power
+sps_power = Sensor("6100_0046C600", "sps_power", unit="W", enabled=False)
+
 # PV Inverter Optimizers
 #: Serial number of optimizer
 optimizer_serial = Sensor("6800_10852600", "optimizer_serial")
@@ -482,6 +490,9 @@ sensor_map = {
         power_l1,
         power_l2,
         power_l3,
+        sps_voltage,
+        sps_current,
+        sps_power,
         total_yield,
         daily_yield,
         pv_gen_meter,


### PR DESCRIPTION
- Add definitions for the Secure Power Supply (labeled "Emergency power measurements" in the web interface) for voltage, current, and power.

Hello!
I would like to expose some additional data from the SMA web portal through pysma to home assistant. I have added the sensors to `definitions.py`. I have done my best to follow existing patterns and documentation. I'm also not sure if I'm missing anything else to be able to access this data in home assistant. Any guidance would be greatly appreciated.

Thanks in advance!
