### PR TITLE
Pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ disallow_untyped_defs = True
 [pydocstyle]
 match_dir=pysma
 convention=google
+
+[tool:pytest]
+asyncio_mode=auto


### PR DESCRIPTION
Sets the pytest asyncio_mode to auto to fix skipped tests.