### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args:
           - --quiet
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
I was not able to use pre-commit hook in this project:
```
      RuntimeError: The Poetry configuration is invalid:
        - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```
After some googling I found the following article that explains the issue in details: https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The fix is quite simple, updating the isort dependency to 5.12.0.

With that change the pre-commit hook works as expected.
