### PR TITLE
Retry transient request failures with a short per-attempt timeout

### DIFF
--- a/src/pysma/const.py
+++ b/src/pysma/const.py
@@ -11,7 +11,8 @@ URL_DASH_VALUES = "/dyn/getDashValues.json"
 
 USERS = {"user": "usr", "installer": "istl"}
 
-DEFAULT_TIMEOUT = 15
+DEFAULT_TIMEOUT = 5  # seconds, per attempt
+DEFAULT_REQUEST_RETRIES = 3  # attempts per request
 DEFAULT_LANG = "en-US"
 
 JMESPATH_VAL = "val"

--- a/src/pysma/sma_webconnect.py
+++ b/src/pysma/sma_webconnect.py
@@ -18,6 +18,7 @@ from aiohttp import ClientSession, ClientTimeout, client_exceptions, hdrs
 
 from .const import (
     DEFAULT_LANG,
+    DEFAULT_REQUEST_RETRIES,
     DEFAULT_TIMEOUT,
     DEVICE_INFO,
     ENERGY_METER_VIA_INVERTER,
@@ -118,7 +119,7 @@ class SMAWebConnect:
 
         _LOG.debug("Sending %s request to %s: %s", method, url, kwargs)
 
-        max_retries = 2
+        max_retries = DEFAULT_REQUEST_RETRIES
         for retry in range(max_retries):
             try:
                 async with self.session.request(
@@ -133,21 +134,15 @@ class SMAWebConnect:
             except (client_exceptions.ContentTypeError, json.decoder.JSONDecodeError):
                 _LOG.warning("Request to %s did not return a valid json.", url)
                 break
-            except client_exceptions.ServerDisconnectedError as exc:
-                if (retry + 1) < max_retries:
-                    # For some reason the SMA device sometimes raises a server disconnected error
-                    # If this happens we will retry up to `max_retries` times
-                    # This prevents errors in Home Assistant
-                    _LOG.debug("ServerDisconnectedError, will retry connection.")
-                    continue
-
-                raise SmaConnectionException(
-                    f"Server at {self.url} disconnected {max_retries + 1} times."
-                ) from exc
             except (
+                client_exceptions.ServerDisconnectedError,
                 client_exceptions.ClientError,
                 asyncio.exceptions.TimeoutError,
             ) as exc:
+                if (retry + 1) < max_retries:
+                    _LOG.debug("Retrying %s (%d/%d)", url, retry + 1, max_retries)
+                    continue
+
                 raise SmaConnectionException(
                     f"Could not connect to SMA at {self.url}: {exc}"
                 ) from exc


### PR DESCRIPTION
## Problem

`_request_json` retries only `ServerDisconnectedError`. An `asyncio.TimeoutError` or `ClientError` (the usual symptom of packet loss) raises `SmaConnectionException` immediately with no retry, on a single request with a 15s timeout. On a lossy network a single long attempt often fails outright, so Home Assistant marks the whole device unavailable on one missed poll and the entities flap (cycling available and unavailable every minute or two), even though most polls would succeed on a quick retry.

## Change

Retry all transient connection failures (timeouts, disconnects, generic client errors) with a fresh connection, not just `ServerDisconnectedError`. `DEFAULT_TIMEOUT` becomes a per-attempt timeout (5s) with `DEFAULT_REQUEST_RETRIES` (3) attempts, so the total request time stays about 15s, now spread over 3 independent attempts instead of 1. A fresh short attempt resets TCP backoff and samples the link several times, which recovers better than one long attempt whose stuck connection keeps retransmitting.

## Evidence

Measured against a real SMA inverter on a WiFi link with 64 to 86% packet loss, 18 poll cycles on the identical link:

| Strategy | Per-poll success |
|---|---|
| current (1 x 15s) | 44% |
| 3 x 6s retry | 72% |
| 6 x 2.5s retry | 72% |

Retry roughly halves the flapping. The residual failures are multi-second dead bursts longer than any timeout budget, which the client cannot fix. A separate live test in Home Assistant showed about 45% fewer dropouts at the same poll interval.

## Notes

The exact values (5s and 3 attempts) keep the original 15s worst-case budget and are easy to tune. `DEFAULT_TIMEOUT` changes meaning from a single request timeout to a per-attempt timeout; I can add a separate constant instead if you prefer to keep its semantics. The previous "Server at ... disconnected N times." message is folded into the existing "Could not connect to SMA at ...: ..." message. Existing tests pass unchanged (25 passed) and ruff format and ruff check are clean.
